### PR TITLE
remove dangling comma to fix terser parsing in webpack

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,12 +9,11 @@ const join = (str, d) => words(str).join(d).toLowerCase()
 const camelCase = (str) =>
   words(str).reduce(
     (acc, next) =>
-      `${acc}${
-        !acc
-          ? next.toLowerCase()
-          : next[0].toUpperCase() + next.slice(1).toLowerCase()
+      `${acc}${!acc
+        ? next.toLowerCase()
+        : next[0].toUpperCase() + next.slice(1).toLowerCase()
       }`,
-    '',
+    ''
   )
 
 const pascalCase = (str) => upperFirst(camelCase(str))


### PR DESCRIPTION
When using Terser to minify (with webpack 4), the trailing comma returns the following stacktrace:

ERROR in main.js from Terser
Unexpected token: punc()) [...]

After some digging, I found that removing the trailing comma on line 17 in the index.js fixes this problem.